### PR TITLE
Adding diagnostic message to print raw IMU cached value

### DIFF
--- a/2025-MECHS-Rob/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/2025-MECHS-Rob/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -76,6 +76,7 @@ public class SwerveSubsystem extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    System.out.println("Raw IMU reading: " + swerveDrive.imuReadingCache.getValue());
   }
 
   @Override


### PR DESCRIPTION
This change adds a diagnostic message to print out the cached IMU value from the `drivebase` object. Right now, it seems to be the most direct way to access whatever data is coming from the IMU, but there could be other ways to do this.